### PR TITLE
Changed PHP version to require the correct version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A secure, open source torrent cache.
 ## Dependencies
 
 - [Composer]
-- PHP 7.0 or greater
+- PHP 7.1 or greater
 - A web server
 
 ## Installation


### PR DESCRIPTION
When running `composer install` it says in requires php7.1, but the readme says the project requires php7.0, which is false.