### PR TITLE
Fixes #7 (Cleanly without editing previously committed Migration File)

### DIFF
--- a/app/Torrent.php
+++ b/app/Torrent.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Storage;
 /**
  * @property int    $id
  * @property string $hash
+ * @property string $filename
  * @property string deleted_at
  * @property string created_at
  * @property string updated_at
@@ -33,6 +34,7 @@ class Torrent extends Model
         if ($file->extension() === 'torrent') {
             $torrent = new \Torrent($file->getRealPath());
             $this->hash = $torrent->hash_info();
+            $this->filename = $file->getClientOriginalName();
 
             if ($this->hash) {
                 if (!Storage::exists('torrents/' . $this->hash . '.torrent')) {

--- a/app/Torrent.php
+++ b/app/Torrent.php
@@ -34,7 +34,7 @@ class Torrent extends Model
         if ($file->extension() === 'torrent') {
             $torrent = new \Torrent($file->getRealPath());
             $this->hash = $torrent->hash_info();
-            $this->filename = $file->getClientOriginalName();
+            $this->filename = $torrent->name();
 
             if ($this->hash) {
                 if (!Storage::exists('torrents/' . $this->hash . '.torrent')) {

--- a/database/migrations/2017_10_26_050611_add_filename_to_torrents_table.php
+++ b/database/migrations/2017_10_26_050611_add_filename_to_torrents_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddFilenameToTorrentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('torrents', function (Blueprint $table) {
+            $table->string('filename')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('torrents', function (Blueprint $table) {
+            $table->dropColumn('filename');
+        });
+    }
+}

--- a/resources/views/torrents/_info.blade.php
+++ b/resources/views/torrents/_info.blade.php
@@ -19,6 +19,10 @@
                 <td class="ellipsis">{{ $torrent->hash }}</td>
             </tr>
             <tr>
+                <th>Original File Name</th>
+                <td class="ellipsis">{{ $torrent->filename }}</td>
+            </tr>
+            <tr>
                 <th>Size</th>
                 <td class="ellipsis">{{ \Rych\ByteSize\ByteSize::formatMetric($file->getSize() ?? $file->size()) }}</td>
             </tr>


### PR DESCRIPTION
The issue is roughly based off of @ventrec 's solution but I create new migration file to add filename as a nullable string to Torrents table, instead of editing existing migration file (Habits from RoR)

Hope it helps.
`Also a clone of a previous PR I closed as to work on a different Issue`

> Fixes #7 Add name listing to Torrent Files