### PR TITLE
Fixes #5 

### DIFF
--- a/app/Http/Controllers/StatisticController.php
+++ b/app/Http/Controllers/StatisticController.php
@@ -53,4 +53,23 @@ class StatisticController extends Controller
             ])->setStatusCode(404);
         }
     }
+
+    /**
+     * Destroys all .torrent files from database entries
+     * @return \Illuminate\Http\Response
+     */
+    public function purge()
+    {
+        $result = Torrent::truncate()->get()->count() == 0;
+        if ($result) {
+            return response()->json([
+                'success' => $result,
+                'message' => 'Purge Successful!'
+            ])->setStatusCode(200);
+        } else {
+            return response()->json([
+                'error' => 'Cannot Purge Torrents.'
+            ])->setStatusCode(500);
+        }
+    }
 }

--- a/resources/views/statistics/_info.blade.php
+++ b/resources/views/statistics/_info.blade.php
@@ -25,6 +25,37 @@
                 <th>Total Torrents</th>
                 <td class="ellipsis">{{ $totalTorrentsWithDeleted }} ({{ $totalTorrents }} active)</td>
             </tr>
+            <tr>
+                <th>Clear All Torrents</th>
+                <td class="ellipsis">
+                    <form id="purgeForm" action="">
+                        {{ csrf_field() }}
+                        <button type="submit" class="btn btn-default btn-danger btn-wide btn-text-left">
+                            <span id="purgeButton">Purge</span>
+                        </button>
+                    </form>
+                    <script>
+                    console.log('Page loaded');
+                    document.getElementById('purgeForm').addEventListener('submit', function(e) {
+                        e.preventDefault(); //Prevents default submit
+                        console.log('Purge Form Activated');
+                        var form = $(this); 
+                        var post_data = form.serialize(); //Serialized the form data for process.php
+                        $('#purgeButton', form).text('Purging...')
+                        $.ajax({
+                            type: 'DELETE',
+                            url: '{{ route('statistics.purge') }}', // Your form script
+                            data: post_data,
+                            success: function(result) {
+                                $('#purgeButton', form).fadeOut(500, function(){
+                                    form.html(result.message).fadeIn();
+                                });
+                            }
+                        });
+                    });
+                    </script>
+                </td>
+            </tr>
         </table>
     </div>
 </div>

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Foundation\Inspiring;
+use App\Torrent;
 
 /*
 |--------------------------------------------------------------------------
@@ -16,3 +17,7 @@ use Illuminate\Foundation\Inspiring;
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->describe('Display an inspiring quote');
+
+Artisan::command('cachent:clear', function() {
+    $this->comment(Torrent::truncate()->get()->count() == 0 ? 'All entries in Torrents have been purged.' : 'Purge Unsuccessful!');
+})->describe('Truncate Torrents table (Destroy all entries)');

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,7 @@ Route::group(['middleware' => ['auth']], function () {
     Route::delete('torrents/{hash}', 'TorrentController@destroy')->name('torrents.delete');
     Route::get('statistics', 'StatisticController@index')->name('statistics.index');
     Route::get('statistics/{hash}', 'StatisticController@show')->name('statistics.show');
+    Route::delete('statistics', 'StatisticController@purge')->name('statistics.purge');
 });
 
 // Authentication


### PR DESCRIPTION
A newly created Pull-Request that directly addresses Issue #5 Admin Permanent Remove
Adds two new functionalities:
1. Using Web Interface, Admin can Click Purge Button on Statistics Index Page to Truncate Torrents Table (Destroy all entries)
2. Using Command-Line Interface, can also Truncate Torrents Table by using this command line
> php artisan cachent:clear

A successful truncation will return with this message:
> All entries in Torrents have been purged.

and an unsuccessful operation will return:
> Purge Unsuccessful!